### PR TITLE
Fix : Subcategory required while adding a new product

### DIFF
--- a/Dtos/Products/CreateProductRequestDto.cs
+++ b/Dtos/Products/CreateProductRequestDto.cs
@@ -46,5 +46,11 @@ namespace MaplenouApi.Dtos.Products
         /// </summary>
         [Required]
         public List<IFormFile> Images { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the ID of the subcategory the product belongs to.
+        /// </summary>
+        [Required(ErrorMessage = "SubcategoryId is required.")]
+        public Guid SubcategoryId { get; set; }
     }
 }

--- a/Mappers/ProductMappers.cs
+++ b/Mappers/ProductMappers.cs
@@ -48,6 +48,7 @@ namespace MaplenouApi.Mappers
                 Description = productRequestDto.Description,
                 Price = productRequestDto.Price,
                 Quantity = productRequestDto.Quantity,
+                SubcategoryId = productRequestDto.SubcategoryId,
             };
         }
     }


### PR DESCRIPTION
the subcategory which the product belongs to, is now required while adding a new product.

this close issue #22 