### PR TITLE
Feat(Category): add GetById functionality to retrieve category by ID

### DIFF
--- a/Controllers/CategoryController.cs
+++ b/Controllers/CategoryController.cs
@@ -47,6 +47,23 @@ namespace MaplenouApi.Controllers
         }
 
         /// <summary>
+        /// Retrieves a category by its unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the category.</param>
+        /// <returns>The category DTO if found; otherwise, NotFound.</returns>
+        [HttpGet("{id:guid}")]
+        public async Task<IActionResult> GetById(Guid id)
+        {
+            var category = await this._categoryRepo.GetByIdAsync(id);
+            if (category == null)
+            {
+                return this.NotFound();
+            }
+
+            return this.Ok(category.ToCategoryDto());
+        }
+
+        /// <summary>
         /// Creates a new category based on the provided request data.
         /// </summary>
         /// <param name="categoryRequestDto">The DTO containing the data for the new category.</param>
@@ -61,7 +78,7 @@ namespace MaplenouApi.Controllers
 
             var categoryModel = categoryRequestDto.ToCategoryFromCreateDto();
             await this._categoryRepo.CreateAsync(categoryModel);
-            return this.Ok(categoryModel.ToCategoryDto());
+            return this.CreatedAtAction(nameof(this.GetById), new { id = categoryModel.Id }, categoryModel.ToCategoryDto());
         }
     }
 }

--- a/Interfaces/ICategoryRepository.cs
+++ b/Interfaces/ICategoryRepository.cs
@@ -29,5 +29,12 @@ namespace MaplenouApi.Interfaces
         /// <param name="categoryModel">The category model to create.</param>
         /// <returns>A task representing the asynchronous operation, with the created <see cref="Category"/> as the result.</returns>
         Task<Category> CreateAsync(Category categoryModel);
+
+        /// <summary>
+        /// Asynchronously retrieves a category by its unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the category.</param>
+        /// <returns>A task representing the asynchronous operation, with the <see cref="Category"/> entity as the result, or null if not found.</returns>
+        Task<Category?> GetByIdAsync(Guid id);
     }
 }

--- a/Repository/CategoryRepository.cs
+++ b/Repository/CategoryRepository.cs
@@ -68,5 +68,15 @@ namespace MaplenouApi.Repository
             await this._context.SaveChangesAsync();
             return categoryModel;
         }
+
+        /// <summary>
+        /// Retrieves a category by its unique identifier asynchronously.
+        /// </summary>
+        /// <param name="id">The unique identifier of the category.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the category if found; otherwise, null.</returns>
+        public async Task<Category?> GetByIdAsync(Guid id)
+        {
+            return await this._context.Categories.FirstOrDefaultAsync(c => c.Id == id);
+        }
     }
 }


### PR DESCRIPTION
**Summary**
Users can now a retrieve a category by its ID

**What Have been Done ?**

- Implements GetByIdAsync method in CategoryRepository
- Implements GetById method in controller with GET request.

**What's New ?**
`GET: api/categories/{id}` this endpoint will retrieve the category that match the id in parameter.