### PR TITLE
Feat(Category): add Delete functionality to remove categories by ID

### DIFF
--- a/Controllers/CategoryController.cs
+++ b/Controllers/CategoryController.cs
@@ -105,5 +105,23 @@ namespace MaplenouApi.Controllers
 
             return this.Ok(updatedCategory.ToCategoryDto());
         }
+
+        /// <summary>
+        /// Deletes a category with the specified unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the category to delete.</param>
+        /// <returns>NoContent if successful; otherwise, NotFound.</returns>
+        [HttpDelete]
+        [Route("{id:guid}")]
+        public async Task<IActionResult> Delete([FromRoute] Guid id)
+        {
+            var deletedCategory = await this._categoryRepo.DeleteAsync(id);
+            if (deletedCategory == null)
+            {
+                return this.NotFound();
+            }
+
+            return this.NoContent();
+        }
     }
 }

--- a/Interfaces/ICategoryRepository.cs
+++ b/Interfaces/ICategoryRepository.cs
@@ -47,5 +47,11 @@ namespace MaplenouApi.Interfaces
         /// <returns>A task representing the asynchronous operation, with the updated <see cref="Category"/> entity as the result, or null if not found.</returns>
         Task<Category?> UpdateAsync(Guid id, UpdateCategoryRequestDto categoryDto);
 
+        /// <summary>
+        /// Asynchronously deletes a category by its unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the category to delete.</param>
+        /// <returns>A task representing the asynchronous operation, with the deleted <see cref="Category"/> entity as the result, or null if not found.</returns>
+        Task<Category?> DeleteAsync(Guid id);
     }
 }

--- a/Repository/CategoryRepository.cs
+++ b/Repository/CategoryRepository.cs
@@ -101,5 +101,24 @@ namespace MaplenouApi.Repository
 
             return existingCategory;
         }
+
+        /// <summary>
+        /// Deletes a category by its unique identifier asynchronously.
+        /// </summary>
+        /// <param name="id">The unique identifier of the category to delete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the deleted category if found; otherwise, null.</returns>
+        public async Task<Category?> DeleteAsync(Guid id)
+        {
+            var categoryModel = this._context.Categories.FirstOrDefault(c => c.Id == id);
+            if (categoryModel == null)
+            {
+                return null;
+            }
+
+            this._context.Categories.Remove(categoryModel);
+            await this._context.SaveChangesAsync();
+
+            return categoryModel;
+        }
     }
 }


### PR DESCRIPTION
**Summary**
users can now delete a category.

**What have been done ?**

- Implements deleteAsync method in categoryrepository
- Implements delete method in CategoryController

**What's new ?**

`Delete: /api/category/{id}` this endpoint is use for deleting a category by using its id.