### PR TITLE
Feat(Supplier): add Create functionality for suppliers

### DIFF
--- a/Controllers/SupplierController.cs
+++ b/Controllers/SupplierController.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using MaplenouApi.Dtos.Supplier;
 using MaplenouApi.Helpers;
 using MaplenouApi.Interfaces;
 using MaplenouApi.Mappers;
@@ -42,6 +43,25 @@ namespace MaplenouApi.Controllers
             var suppliers = await this._supplierRepo.GetAllAsync(queryObject);
             var suppliersDto = suppliers.Select(sp => sp.ToSupplierDto());
             return this.Ok(suppliersDto);
+        }
+
+        /// <summary>
+        /// Creates a new supplier using the provided supplier data.
+        /// </summary>
+        /// <param name="supplierDto">The supplier data transfer object containing the supplier information.</param>
+        /// <returns>The created supplier DTO.</returns>
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateSupplierRequestDto supplierDto)
+        {
+            if (!this.ModelState.IsValid)
+            {
+                return this.BadRequest(this.ModelState);
+            }
+
+            var supplierModel = supplierDto.ToSupplierFromCreateDto();
+            await this._supplierRepo.CreateAsync(supplierModel);
+            var createdSupplierDto = supplierModel.ToSupplierDto();
+            return this.Ok(createdSupplierDto);
         }
     }
 }

--- a/Dtos/Supplier/CreateSupplierRequestDto.cs
+++ b/Dtos/Supplier/CreateSupplierRequestDto.cs
@@ -1,0 +1,32 @@
+// <copyright file="CreateSupplierRequestDto.cs" company="Maplenou">
+// Copyright © Maplenou 2025
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MaplenouApi.Dtos.Supplier
+{
+    /// <summary>
+    /// Represents the data required to create a supplier.
+    /// </summary>
+    public class CreateSupplierRequestDto
+    {
+        /// <summary>
+        /// Gets or sets the fullname of the supplier.
+        /// </summary>
+        [Required]
+        [MaxLength(50, ErrorMessage = "Name cannot exceed 50 characters.")]
+        public string FullName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the phoneNumber of the supplier.
+        /// </summary>
+        [Required]
+        [MaxLength(30, ErrorMessage = "Name cannot exceed 30 characters.")]
+        public string PhoneNumber { get; set; } = string.Empty;
+    }
+}

--- a/Interfaces/ISupplierRepository.cs
+++ b/Interfaces/ISupplierRepository.cs
@@ -22,5 +22,12 @@ namespace MaplenouApi.Interfaces
         /// <param name="queryObject">The query object containing filter parameters.</param>
         /// <returns>A list of suppliers matching the query.</returns>
         public Task<List<Supplier>> GetAllAsync(SupplierQueryObject queryObject);
+
+        /// <summary>
+        /// Creates a new supplier asynchronously.
+        /// </summary>
+        /// <param name="supplierModel">The supplier model to create.</param>
+        /// <returns>The created supplier.</returns>
+        Task<Supplier> CreateAsync(Supplier supplierModel);
     }
 }

--- a/Mappers/SupplierMappers.cs
+++ b/Mappers/SupplierMappers.cs
@@ -31,5 +31,20 @@ namespace MaplenouApi.Mappers
                 CreatedOn = supplierModel.CreatedOn,
             };
         }
+
+        /// <summary>
+        /// Converts a <see cref="CreateSupplierRequestDto"/> to a <see cref="Supplier"/> model.
+        /// </summary>
+        /// <param name="supplierRequestDto">The DTO containing supplier creation data.</param>
+        /// <returns>A new <see cref="Supplier"/> instance populated from the DTO.</returns>
+        public static Supplier ToSupplierFromCreateDto(this CreateSupplierRequestDto supplierRequestDto)
+        {
+            return new Supplier
+            {
+                FullName = supplierRequestDto.FullName,
+                PhoneNumber = supplierRequestDto.PhoneNumber,
+                ProductSuppliers = new List<ProductSupplier>(), // Initialize to avoid null reference
+            };
+        }
     }
 }

--- a/Repository/SupplierRepository.cs
+++ b/Repository/SupplierRepository.cs
@@ -14,6 +14,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace MaplenouApi.Repository
 {
+    /// <summary>
+    /// Repository class for managing supplier data.
+    /// </summary>
     public class SupplierRepository : ISupplierRepository
     {
         private readonly ApplicationDBContext _context;
@@ -25,6 +28,18 @@ namespace MaplenouApi.Repository
         public SupplierRepository(ApplicationDBContext context)
         {
             this._context = context;
+        }
+
+        /// <summary>
+        /// Creates a new supplier asynchronously and saves it to the database.
+        /// </summary>
+        /// <param name="supplierModel">The supplier model to create.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the created supplier.</returns>
+        public async Task<Supplier> CreateAsync(Supplier supplierModel)
+        {
+            await this._context.Suppliers.AddAsync(supplierModel);
+            await this._context.SaveChangesAsync();
+            return supplierModel;
         }
 
         /// <summary>


### PR DESCRIPTION
**Summary**
Users can now add a supplier.

**What Have been done ?**

- Created a Dto as a request for creating a new supplier
- Implements CreateAsync method in SupplierRepository
- Implements Create method in SupplierController

**What's New ?**
`POST:  /api/Suppliers` this endpoint is use for creating a new Supplier.