### PR TITLE
Feat(Supplier): add GetById functionality to retrieve a supplier by ID

### DIFF
--- a/Controllers/SupplierController.cs
+++ b/Controllers/SupplierController.cs
@@ -46,6 +46,24 @@ namespace MaplenouApi.Controllers
         }
 
         /// <summary>
+        /// Retrieves a supplier by its unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the supplier.</param>
+        /// <returns>The supplier DTO if found; otherwise, NotFound.</returns>
+        [HttpGet]
+        [Route("{id:guid}")]
+        public async Task<IActionResult> GetById(Guid id)
+        {
+            var supplier = await this._supplierRepo.GetByIdAsync(id);
+            if (supplier == null)
+            {
+                return this.NotFound();
+            }
+
+            return this.Ok(supplier.ToSupplierDto());
+        }
+
+        /// <summary>
         /// Creates a new supplier using the provided supplier data.
         /// </summary>
         /// <param name="supplierDto">The supplier data transfer object containing the supplier information.</param>
@@ -61,7 +79,7 @@ namespace MaplenouApi.Controllers
             var supplierModel = supplierDto.ToSupplierFromCreateDto();
             await this._supplierRepo.CreateAsync(supplierModel);
             var createdSupplierDto = supplierModel.ToSupplierDto();
-            return this.Ok(createdSupplierDto);
+            return this.CreatedAtAction(nameof(this.GetById), new { id = createdSupplierDto.SupplierId }, createdSupplierDto);
         }
     }
 }

--- a/Interfaces/ISupplierRepository.cs
+++ b/Interfaces/ISupplierRepository.cs
@@ -29,5 +29,12 @@ namespace MaplenouApi.Interfaces
         /// <param name="supplierModel">The supplier model to create.</param>
         /// <returns>The created supplier.</returns>
         Task<Supplier> CreateAsync(Supplier supplierModel);
+
+        /// <summary>
+        /// Gets a supplier by its unique identifier asynchronously.
+        /// </summary>
+        /// <param name="id">The unique identifier of the supplier.</param>
+        /// <returns>The supplier with the specified ID, or null if not found.</returns>
+        Task<Supplier?> GetByIdAsync(Guid id);
     }
 }

--- a/Repository/SupplierRepository.cs
+++ b/Repository/SupplierRepository.cs
@@ -62,5 +62,15 @@ namespace MaplenouApi.Repository
                         .Take(queryObject.PageSize)
                         .ToListAsync();
         }
+
+        /// <summary>
+        /// Retrieves a supplier by its unique identifier asynchronously.
+        /// </summary>
+        /// <param name="id">The unique identifier of the supplier.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the supplier if found; otherwise, null.</returns>
+        public async Task<Supplier?> GetByIdAsync(Guid id)
+        {
+            return await this._context.Suppliers.FirstOrDefaultAsync(sp => sp.SupplierId == id);
+        }
     }
 }


### PR DESCRIPTION
**Summary**
Users can now retrieve a supply info by using its Id

**What Have Been Done ?**

- Implements GetByIdAsync method in supplier repository
- Implements GetById method in SupplierController

**What's New ?**
`GET: api/suppliers/{id}` this endpoint is use for retrieving a supplier infos by using its Id.