### PR TITLE
Feat(Supplier): add Update functionality to modify existing supplier details

### DIFF
--- a/Controllers/SupplierController.cs
+++ b/Controllers/SupplierController.cs
@@ -81,5 +81,30 @@ namespace MaplenouApi.Controllers
             var createdSupplierDto = supplierModel.ToSupplierDto();
             return this.CreatedAtAction(nameof(this.GetById), new { id = createdSupplierDto.SupplierId }, createdSupplierDto);
         }
+
+        /// <summary>
+        /// Updates an existing supplier with the specified ID using the provided supplier data.
+        /// </summary>
+        /// <param name="id">The unique identifier of the supplier to update.</param>
+        /// <param name="supplierDto">The supplier data transfer object containing the updated information.</param>
+        /// <returns>The updated supplier DTO if successful; otherwise, NotFound or BadRequest.</returns>
+        [HttpPut]
+        [Route("{id:guid}")]
+        public async Task<IActionResult> Update([FromRoute] Guid id, [FromBody] UpdateSupplierRequestDto supplierDto)
+        {
+            if (!this.ModelState.IsValid)
+            {
+                return this.BadRequest(this.ModelState);
+            }
+
+            var supplierModel = await this._supplierRepo.UpdateAsync(id, supplierDto);
+
+            if (supplierModel == null)
+            {
+                return this.NotFound();
+            }
+
+            return this.Ok(supplierModel.ToSupplierDto());
+        }
     }
 }

--- a/Dtos/Supplier/UpdateSupplierRequestDto.cs
+++ b/Dtos/Supplier/UpdateSupplierRequestDto.cs
@@ -1,0 +1,32 @@
+// <copyright file="UpdateSupplierRequestDto.cs" company="Maplenou">
+// Copyright © Maplenou 2025
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MaplenouApi.Dtos.Supplier
+{
+    /// <summary>
+    /// DTO for updating supplier information.
+    /// </summary>
+    public class UpdateSupplierRequestDto
+    {
+        /// <summary>
+        /// Gets or sets the fullname of the supplier.
+        /// </summary>
+        [Required]
+        [MaxLength(50, ErrorMessage = "Name cannot exceed 50 characters.")]
+        public string FullName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the phoneNumber of the supplier.
+        /// </summary>
+        [Required]
+        [MaxLength(30, ErrorMessage = "Name cannot exceed 30 characters.")]
+        public string PhoneNumber { get; set; } = string.Empty;
+    }
+}

--- a/Interfaces/ISupplierRepository.cs
+++ b/Interfaces/ISupplierRepository.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using MaplenouApi.Dtos.Supplier;
 using MaplenouApi.Helpers;
 using MaplenouApi.Models;
 
@@ -36,5 +37,13 @@ namespace MaplenouApi.Interfaces
         /// <param name="id">The unique identifier of the supplier.</param>
         /// <returns>The supplier with the specified ID, or null if not found.</returns>
         Task<Supplier?> GetByIdAsync(Guid id);
+
+        /// <summary>
+        /// Updates an existing supplier asynchronously.
+        /// </summary>
+        /// <param name="id">The unique identifier of the supplier to update.</param>
+        /// <param name="supplierDto">The DTO containing updated supplier information.</param>
+        /// <returns>The updated supplier, or null if not found.</returns>
+        Task<Supplier?> UpdateAsync(Guid id, UpdateSupplierRequestDto supplierDto);
     }
 }

--- a/Repository/SupplierRepository.cs
+++ b/Repository/SupplierRepository.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MaplenouApi.Data;
+using MaplenouApi.Dtos.Subcategory;
+using MaplenouApi.Dtos.Supplier;
 using MaplenouApi.Helpers;
 using MaplenouApi.Interfaces;
 using MaplenouApi.Models;
@@ -71,6 +73,29 @@ namespace MaplenouApi.Repository
         public async Task<Supplier?> GetByIdAsync(Guid id)
         {
             return await this._context.Suppliers.FirstOrDefaultAsync(sp => sp.SupplierId == id);
+        }
+
+        /// <summary>
+        /// Updates an existing supplier asynchronously with the provided data.
+        /// </summary>
+        /// <param name="id">The unique identifier of the supplier to update.</param>
+        /// <param name="supplierDto">The DTO containing updated supplier information.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation. The task result contains the updated supplier if found; otherwise, null.
+        /// </returns>
+        public async Task<Supplier?> UpdateAsync(Guid id, UpdateSupplierRequestDto supplierDto)
+        {
+            var existingSupplier = await this._context.Suppliers.FirstOrDefaultAsync(sp => sp.SupplierId == id);
+            if (existingSupplier == null)
+            {
+                return null;
+            }
+
+            existingSupplier.FullName = supplierDto.FullName;
+            existingSupplier.PhoneNumber = supplierDto.PhoneNumber;
+
+            await this._context.SaveChangesAsync();
+            return existingSupplier;
         }
     }
 }


### PR DESCRIPTION
**Summary**
Users can now update a supplier details.

**What Have Been Done ?**

- Implements UpdateAsync method in supplier repository
- Implements Update method in SupplierController

**What's New ?**
`PUT: api/suppliers/{id}` this endpoint is use for updating a supplier infos by using its Id.