### PR TITLE
Feat(Supplier): add Delete functionality to remove a supplier by ID

### DIFF
--- a/Controllers/SupplierController.cs
+++ b/Controllers/SupplierController.cs
@@ -106,5 +106,23 @@ namespace MaplenouApi.Controllers
 
             return this.Ok(supplierModel.ToSupplierDto());
         }
+
+        /// <summary>
+        /// Deletes a supplier with the specified unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the supplier to delete.</param>
+        /// <returns>The deleted supplier DTO if successful; otherwise, NotFound.</returns>
+        [HttpDelete]
+        [Route("{id:guid}")]
+        public async Task<IActionResult> Delete([FromRoute] Guid id)
+        {
+            var supplier = await this._supplierRepo.DeleteAsync(id);
+            if (supplier == null)
+            {
+                return this.NotFound();
+            }
+
+            return this.NoContent();
+        }
     }
 }

--- a/Interfaces/ISupplierRepository.cs
+++ b/Interfaces/ISupplierRepository.cs
@@ -45,5 +45,12 @@ namespace MaplenouApi.Interfaces
         /// <param name="supplierDto">The DTO containing updated supplier information.</param>
         /// <returns>The updated supplier, or null if not found.</returns>
         Task<Supplier?> UpdateAsync(Guid id, UpdateSupplierRequestDto supplierDto);
+
+        /// <summary>
+        /// Deletes a supplier by its unique identifier asynchronously.
+        /// </summary>
+        /// <param name="id">The unique identifier of the supplier to delete.</param>
+        /// <returns>The deleted supplier, or null if not found.</returns>
+        Task<Supplier?> DeleteAsync(Guid id);
     }
 }

--- a/Repository/SupplierRepository.cs
+++ b/Repository/SupplierRepository.cs
@@ -45,6 +45,27 @@ namespace MaplenouApi.Repository
         }
 
         /// <summary>
+        /// Deletes a supplier by its unique identifier asynchronously.
+        /// </summary>
+        /// <param name="id">The unique identifier of the supplier to delete.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation. The task result contains the deleted supplier if found; otherwise, null.
+        /// </returns>
+        public async Task<Supplier?> DeleteAsync(Guid id)
+        {
+            var supplierModel = await this._context.Suppliers.FirstOrDefaultAsync(sp => sp.SupplierId == id);
+            if (supplierModel == null)
+            {
+                return null;
+            }
+
+            this._context.Suppliers.Remove(supplierModel);
+            await this._context.SaveChangesAsync();
+
+            return supplierModel;
+        }
+
+        /// <summary>
         /// Retrieves a paginated list of suppliers based on the specified query object.
         /// </summary>
         /// <param name="queryObject">The query object containing filter and pagination parameters.</param>


### PR DESCRIPTION
**Summary**
Users can now delete a supplier details.

**What Have Been Done ?**

- Implements DeleteAsync method in supplier repository
- Implements Delete method in SupplierController

**What's New ?**
`DELETE: api/suppliers/{id}` this endpoint is use for deleting a supplier by using its Id.