### PR TITLE
Feat(ProductSupplier): implement delete functionality for product suppliers association

### DIFF
--- a/Controllers/ProductSupplierController.cs
+++ b/Controllers/ProductSupplierController.cs
@@ -133,5 +133,23 @@ namespace MaplenouApi.Controllers
 
             return this.Ok(productSupplierModel.ToProductSupplierDto());
         }
+
+        /// <summary>
+        /// Deletes a product supplier by its unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the product supplier to delete.</param>
+        /// <returns>NoContent if deleted; otherwise, NotFound.</returns>
+        [HttpDelete]
+        [Route("{id:guid}")]
+        public async Task<IActionResult> Delete([FromRoute] Guid id)
+        {
+            var productSupplierModel = await this._productSupplierRepo.DeleteAsync(id);
+            if (productSupplierModel == null)
+            {
+                return this.NotFound();
+            }
+
+            return this.NoContent();
+        }
     }
 }

--- a/Interfaces/IProductSupplierRepository.cs
+++ b/Interfaces/IProductSupplierRepository.cs
@@ -45,5 +45,12 @@ namespace MaplenouApi.Interfaces
         /// <param name="productSupplierRequestDto">The DTO containing updated values for the ProductSupplier entity.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the updated ProductSupplier entity if found; otherwise, null.</returns>
         Task<ProductSupplier?> UpdateAsync(Guid id, UpdateProductSupplierRequestDto productSupplierRequestDto);
+
+        /// <summary>
+        /// Deletes a ProductSupplier entity by its unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the ProductSupplier entity to delete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the deleted ProductSupplier entity if found; otherwise, null.</returns>
+        Task<ProductSupplier?> DeleteAsync(Guid id);
     }
 }

--- a/Repository/ProductSupplierRepository.cs
+++ b/Repository/ProductSupplierRepository.cs
@@ -97,5 +97,26 @@ namespace MaplenouApi.Repository
 
             return existingProductSupplier;
         }
+
+        /// <summary>
+        /// Deletes a <see cref="ProductSupplier"/> entity by its unique identifier asynchronously.
+        /// </summary>
+        /// <param name="id">The unique identifier of the <see cref="ProductSupplier"/> to delete.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation. The task result contains the deleted <see cref="ProductSupplier"/> if found; otherwise, <c>null</c>.
+        /// </returns>
+        public async Task<ProductSupplier?> DeleteAsync(Guid id)
+        {
+            var productSupplierModel = await this._context.ProductSuppliers.FirstOrDefaultAsync(ps => ps.Id == id);
+            if (productSupplierModel == null)
+            {
+                return null;
+            }
+
+            this._context.ProductSuppliers.Remove(productSupplierModel);
+            await this._context.SaveChangesAsync();
+
+            return productSupplierModel;
+        }
     }
 }


### PR DESCRIPTION
**Summary**
Users can now delete a specific relation between suppliers and products.

**What Have Been Done ?**

- Implements DeleteAsync method in repository
- Implements delete method in controller

**What's New ?**
`Delete: /api/product-suppliers/{id} `endpoint is use for deleting a specific relation between a product and its supplier by using corresponding Id.